### PR TITLE
Remove pilcrow (¶) character from heading anchors

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,92 +1,305 @@
 :root{
-  --bg: #0f1720;
-  --card: #0b1220;
-  --muted: #93a3b5;
-  --accent: #7dd3fc;
-  --accent-2: #60a5fa;
-  --glass: rgba(255,255,255,0.03);
-  --radius: 12px;
-  --max-width: 980px;
-  --hf-left:#ff6a00; /* orange */
-  --hf-right:#8b5cf6; /* purple */
-  --bg-dark: #071126;
+  /* Base dark theme */
+  --bg: #000000;
+  --card: #0a0a0a;
+  --surface: #121212;
+  --surface-hover: #1f1f1f;
+  --border: rgba(255, 255, 255, 0.04);
+  --border-hover: rgba(255, 255, 255, 0.06);
+
+  /* Text Colors */
+  --text-primary: #eef2ff;
+  --text-secondary: #cfeef0;
+  --text-muted: #94a3b8;
+
+  /* Accent placeholders - overridden at runtime by index.html script */
+  --accent-1: #22c55e; /* fallback */
+  --accent-2: #16a34a; /* fallback */
+  --accent-rgb: 34,197,94; /* fallback RGB for glows */
+  --accent-primary: var(--accent-1);
+  --accent-secondary: var(--accent-2);
+  --accent-gradient: linear-gradient(135deg,var(--accent-1),var(--accent-2));
+  --accent-hover: linear-gradient(135deg,var(--accent-2),var(--accent-1));
+
+  /* Hacktoberfest-friendly fallbacks (used in a few places) */
+  --hf-orange: #f97316;
+  --hf-purple: #8b5cf6;
+  --hf-gradient: var(--accent-gradient);
+  --hf-gradient-hover: var(--accent-hover);
+
+  /* Interactive States */
+  --success: #10b981;
+  --warning: #f59e0b;
+  --error: #ef4444;
+  --info: #06b6d4;
+
+  /* Spacing & Layout */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --spacing-2xl: 3rem;
+
+  /* Typography */
+  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --shadow-glow: 0 0 20px rgba(var(--accent-rgb), 0.12);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
+  --transition-slow: 350ms ease;
+  --transition-spring: 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --sidebar-width: 320px;
 }
 
-*{box-sizing:border-box}
-html,body,#content{height:100%;}
-body{
-  margin:0; font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial;
-  background: linear-gradient(180deg, #071126 0%, #071b2a 100%);
-  color:#e6eef6; -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-.site{display:flex;min-height:100vh}
+html, body, #content {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-family);
+  background: 
+    radial-gradient(circle at 20% 80%, rgba(var(--accent-rgb), 0.1) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(var(--accent-rgb), 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(var(--accent-rgb), 0.05) 0%, transparent 50%),
+    linear-gradient(135deg, var(--bg) 0%, #0a0a0a 50%, #1a1a1a 100%);
+  background-attachment: fixed;
+  color: var(--text-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  line-height: 1.6;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Smooth scrolling */
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 80px;
+}
+
+/* Selection styling */
+::selection {
+  background: var(--accent-primary);
+  color: white;
+}
+
+::-moz-selection {
+  background: var(--accent-primary);
+  color: white;
+}
+
+.site {
+  display: flex;
+  min-height: 100vh;
+  position: relative;
+}
+
+/* Subtle page overlay using accent */
+.site::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: 
+    radial-gradient(circle at 25% 25%, rgba(var(--accent-rgb), 0.06) 0%, transparent 50%),
+    radial-gradient(circle at 75% 75%, rgba(var(--accent-rgb), 0.04) 0%, transparent 50%),
+    radial-gradient(circle at 50% 50%, rgba(var(--accent-rgb), 0.03) 0%, transparent 70%);
+  background-size: 500px 500px, 400px 400px, 600px 600px;
+  pointer-events: none;
+  z-index: -1;
+  animation: green-float 20s ease-in-out infinite;
+}
+
+@keyframes green-float {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); opacity: 0.7; }
+  50% { transform: translate(15px, -8px) rotate(0.5deg); opacity: 0.9; }
+}
 
 /* Top navigation */
-/* --- Original & Base Styles --- */
 .topnav {
-    background: linear-gradient(90deg, var(--hf-left), var(--hf-right));
-    color: #fff;
-    padding: 12px 20px;
-    position: sticky;
-    top: 0;
-    z-index: 60;
-    box-shadow: 0 6px 24px rgba(11,17,40,0.5);
+  background: rgba(0, 0, 0, 0.95);
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  padding: var(--spacing-md) var(--spacing-xl);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 
+    0 4px 20px rgba(0, 0, 0, 0.5),
+  0 0 20px rgba(var(--accent-rgb), 0.12);
+  transition: all var(--transition-base);
 }
+
 .topnav-inner {
-    max-width: 1200px;
+  max-width: var(--max-width);
     margin: 0 auto;
     display: flex;
     align-items: center;
     justify-content: space-between;
+  gap: var(--spacing-lg);
 }
+
 .topnav .brand {
-    color: #fff;
+  color: var(--text-primary);
     text-decoration: none;
     font-weight: 700;
-    font-size: 1.05rem;
+  font-size: var(--font-size-xl);
     display: flex;
     align-items: center;
-    gap: 10px;
+  gap: var(--spacing-sm);
+  transition: all var(--transition-base);
 }
+
+.topnav .brand:hover {
+  transform: translateY(-1px);
+  color: var(--accent-primary);
+}
+
 .nav-links {
     display: flex;
-    gap: 18px;
+  gap: var(--spacing-md);
+  align-items: center;
 }
+
 .nav-links a {
-    color: rgba(255, 255, 255, 0.95);
+  color: var(--text-secondary);
     text-decoration: none;
-    padding: 8px 10px;
-    border-radius: 8px;
-    transition: background .18s ease;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  font-weight: 500;
+  transition: all var(--transition-base);
+  position: relative;
+  overflow: hidden;
 }
+
+.nav-links a::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: var(--accent-gradient);
+  opacity: 0.1;
+  transition: left var(--transition-base);
+  z-index: -1;
+}
+
 .nav-links a:hover {
-    background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  background: var(--surface);
+  transform: translateY(-1px);
 }
+
+.nav-links a:hover::before {
+  left: 0;
+}
+
 .nav-actions {
     display: flex;
     align-items: center;
-    gap: 12px;
+  gap: var(--spacing-md);
 }
+
 .nav-btn {
     background: transparent;
-    border: 0;
-    color: #fff;
-    font-size: 2.05rem;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: var(--font-size-lg);
     cursor: pointer;
-    padding: 0;
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-md);
     display: flex;
     align-items: center;
+  justify-content: center;
+  transition: all var(--transition-base);
+  min-width: 40px;
+  min-height: 40px;
 }
+
+.nav-btn:hover {
+  background: var(--surface);
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.nav-btn:active {
+  transform: translateY(0);
+}
+
 .nav-cta {
-    background: #021025;
-    color: #fff;
-    padding: 8px 12px;
-    border-radius: 10px;
+  background: var(--hf-gradient);
+  color: white;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-lg);
     text-decoration: none;
+  font-weight: 600;
+  transition: all var(--transition-base);
+  box-shadow: var(--shadow-md);
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-cta::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+  transition: left 0.5s ease;
+}
+
+.nav-cta:hover {
+  background: var(--hf-gradient-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-xl);
+}
+
+.nav-cta:hover::before {
+  left: 100%;
+}
+
+.nav-cta:active {
+  transform: translateY(-1px);
 }
 
 
+/* Mobile navigation */
 #hamburger {
     display: none;
 }
@@ -97,7 +310,19 @@ body{
     }
     
     #hamburger {
-        display: block;
+    display: flex;
+  }
+  
+  .topnav {
+    padding: var(--spacing-md);
+  }
+  
+  .topnav-inner {
+    gap: var(--spacing-md);
+  }
+  
+  .topnav .brand {
+    font-size: var(--font-size-lg);
     }
 }
 
@@ -105,93 +330,1096 @@ body{
     #nav-search-btn {
         display: none;
     }
+  
+  .nav-cta {
+    padding: var(--spacing-sm) var(--spacing-md);
+    font-size: var(--font-size-sm);
+    }
 }
 /* Sidebar */
-.sidebar{
-  width:300px; background:linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01));
-  border-right:1px solid rgba(255,255,255,0.03); padding:20px; display:flex; flex-direction:column; gap:16px;
-  transition: width .35s cubic-bezier(.2,.9,.2,1), transform .35s ease; position:sticky; top:0; height:100vh; overflow:auto;
+.sidebar {
+  width: var(--sidebar-width);
+  background: rgba(10, 10, 10, 0.95);
+  backdrop-filter: blur(20px);
+  border-right: 1px solid var(--border);
+  padding: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  transition: all var(--transition-slow);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: auto;
+  box-shadow: 
+    4px 0 20px rgba(0, 0, 0, 0.5),
+  0 0 20px rgba(var(--accent-rgb), 0.08);
 }
-.sidebar.collapsed{width:70px}
-.brand a{font-weight:700; font-size:18px; color:var(--accent); text-decoration:none}
 
-.search-wrapper{position:relative}
-.search-wrapper input{
-  width:100%; padding:10px 36px 10px 12px; background:linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)); border:1px solid rgba(255,255,255,0.04);
-  color:var(--muted); border-radius:8px; outline:none; transition:box-shadow .2s ease, transform .12s ease;
+.sidebar.collapsed {
+  width: 80px;
+  padding: var(--spacing-md);
 }
-.search-wrapper input:focus{box-shadow:0 6px 20px rgba(96,165,250,0.12); transform:translateY(-1px);}
-.search-ico{position:absolute; right:10px; top:8px; width:20px; height:20px; fill:var(--muted); opacity:.7}
 
-.toc{flex:1; overflow:auto}
-.toc-list{list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px}
-.toc-item a{display:block; padding:8px 10px; color:rgba(255,255,255,0.85); text-decoration:none; border-radius:8px; transition:background .15s ease, color .15s ease, transform .18s cubic-bezier(.2,.9,.2,1)}
-.toc-item a:hover{background:rgba(125,211,252,0.06); color:var(--accent); transform:translateX(4px)}
-.toc-item.toc-h1 a{font-weight:700}
-.toc-item.toc-h2 a{padding-left:14px}
-.toc-item.toc-h3 a{padding-left:26px; font-size:.95em}
-.toc-item.dim a{opacity:.45; transform:none}
-.toc-item a.active{background:linear-gradient(90deg,var(--hf-left),var(--hf-right)); color:#021025; font-weight:700; transform:translateX(2px) scale(1.01)}
-.toc-empty{color:var(--muted); font-style:italic}
+.sidebar.collapsed .brand,
+.sidebar.collapsed .search-wrapper,
+.sidebar.collapsed .toc,
+.sidebar.collapsed .sidebar-footer {
+  display: none;
+}
 
-.toc-toggle{border:0; background:transparent; color:var(--muted); padding:8px; cursor:pointer}
-.sidebar-footer{display:flex; gap:8px; align-items:center}
-.sidebar-footer .btn{display:inline-block; padding:8px 12px; background:rgba(255,255,255,0.03); color:var(--accent-2); border-radius:8px; text-decoration:none}
+.sidebar.collapsed .toc-toggle {
+  position: absolute;
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xs);
+}
+
+.sidebar .brand a {
+  font-weight: 700;
+  font-size: var(--font-size-lg);
+  color: var(--accent-primary);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  transition: all var(--transition-base);
+}
+
+.sidebar .brand a:hover {
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+/* Search wrapper */
+.search-wrapper {
+  position: relative;
+}
+
+.search-wrapper input {
+  width: 100%;
+  padding: var(--spacing-md) var(--spacing-xl) var(--spacing-md) var(--spacing-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  border-radius: var(--radius-lg);
+  outline: none;
+  font-size: var(--font-size-sm);
+  transition: all var(--transition-base);
+  box-shadow: var(--shadow-sm);
+}
+
+.search-wrapper input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.12);
+  background: var(--surface-hover);
+}
+
+.search-wrapper input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-ico {
+  position: absolute;
+  right: var(--spacing-md);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  fill: var(--text-muted);
+  transition: fill var(--transition-base);
+  pointer-events: none;
+}
+
+.search-wrapper input:focus + .search-ico {
+  fill: var(--accent-primary);
+}
+
+/* Table of contents */
+.toc {
+  flex: 1;
+  overflow: auto;
+}
+
+.toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.toc-item a {
+  display: block;
+  padding: var(--spacing-sm) var(--spacing-md);
+  color: var(--text-secondary);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  transition: all var(--transition-base);
+  position: relative;
+  overflow: hidden;
+  border-left: 2px solid transparent;
+}
+
+.toc-item a::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  background: var(--accent-gradient);
+  transform: scaleY(0);
+  transition: transform var(--transition-base);
+}
+
+.toc-item a:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+  transform: translateX(4px);
+  padding-left: calc(var(--spacing-md) + 4px);
+  border-left-color: rgba(var(--accent-rgb), 0.28);
+}
+
+.toc-item a:hover::before {
+  transform: scaleY(1);
+}
+
+.toc-item.toc-h1 a {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+}
+
+.toc-item.toc-h2 a {
+  padding-left: calc(var(--spacing-md) + var(--spacing-sm));
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.toc-item.toc-h3 a {
+  padding-left: calc(var(--spacing-md) + var(--spacing-lg));
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.toc-item.dim a {
+  opacity: 0.4;
+  transform: none;
+}
+
+.toc-item a.active {
+  background: var(--accent-gradient);
+  color: white;
+  font-weight: 600;
+  transform: translateX(6px);
+  box-shadow: var(--shadow-md);
+  border-left: 3px solid var(--accent-primary);
+  padding-left: calc(var(--spacing-md) + 3px);
+}
+
+.toc-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+  padding: var(--spacing-xl);
+}
+
+/* TOC toggle button */
+.toc-toggle {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-muted);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition: all var(--transition-base);
+  position: relative;
+  overflow: hidden;
+}
+
+.toc-toggle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(var(--accent-rgb), 0.08), transparent);
+  transition: left var(--transition-base);
+}
+
+.toc-toggle:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.toc-toggle:hover::before {
+  left: 100%;
+}
+
+.toc-toggle:active {
+  transform: translateY(0);
+}
+
+/* Sidebar footer */
+.sidebar-footer {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  padding-top: var(--spacing-lg);
+  border-top: 1px solid var(--border);
+}
+
+.sidebar-footer .btn {
+  display: inline-block;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--surface);
+  color: var(--accent-primary);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  transition: all var(--transition-base);
+  border: 1px solid var(--border);
+}
+
+.sidebar-footer .btn:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
 
 /* Content */
-.content{flex:1; padding:36px 48px; display:flex; justify-content:center}
-.content-inner{width:100%; max-width:var(--max-width); background:linear-gradient(180deg, rgba(255,255,255,0.01), transparent); padding:36px; border-radius:16px; box-shadow:0 10px 40px rgba(2,6,23,0.6); transition:box-shadow .36s ease, transform .36s ease;}
-.content-inner:hover{box-shadow:0 18px 60px rgba(2,6,23,0.7); transform:translateY(-2px)}
+.content {
+  flex: 1;
+  padding: var(--spacing-2xl);
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
 
-/* Decorative background gradient blob */
-.bg-decor{position:absolute; left:50%; top:4%; width:720px; height:420px; transform:translateX(-50%); background:radial-gradient(circle at 20% 30%, rgba(125,211,252,0.06), transparent 25%), radial-gradient(circle at 80% 70%, rgba(96,165,250,0.05), transparent 30%); filter:blur(20px); pointer-events:none; z-index:0}
-.content-inner{position:relative; z-index:2}
+.content-inner {
+  width: 100%;
+  max-width: var(--max-width);
+  background: rgba(26, 26, 26, 0.9);
+  backdrop-filter: blur(20px);
+  padding: var(--spacing-2xl);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  box-shadow: 
+    var(--shadow-xl),
+  0 0 30px rgba(var(--accent-rgb), 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition: all var(--transition-slow);
+  position: relative;
+  overflow: hidden;
+}
 
-@media (max-width:900px){.bg-decor{display:none}}
+.content-inner::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--accent-gradient);
+  opacity: 0.8;
+  animation: green-glow 4s ease-in-out infinite alternate;
+}
+
+.content-inner::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(45deg, transparent 30%, rgba(var(--accent-rgb), 0.02) 50%, transparent 70%);
+  pointer-events: none;
+}
+
+.content-inner:hover {
+  box-shadow: 
+    var(--shadow-xl),
+  0 0 40px rgba(var(--accent-rgb), 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  transform: translateY(-4px);
+  border-color: var(--border-hover);
+}
+
+@keyframes green-glow {
+  0% { 
+    opacity: 0.8; 
+  box-shadow: 0 0 5px rgba(var(--accent-rgb), 0.28);
+  }
+  100% { 
+    opacity: 1; 
+  box-shadow: 0 0 15px rgba(var(--accent-rgb), 0.46);
+  }
+}
+
+/* Decorative background elements */
+.bg-decor {
+  position: absolute;
+  left: 50%;
+  top: 4%;
+  width: 720px;
+  height: 420px;
+  transform: translateX(-50%);
+  background: 
+  radial-gradient(circle at 20% 30%, rgba(var(--accent-rgb), 0.08), transparent 25%),
+  radial-gradient(circle at 80% 70%, rgba(var(--accent-rgb), 0.06), transparent 30%);
+  filter: blur(40px);
+  pointer-events: none;
+  z-index: 0;
+  animation: green-float-decor 10s ease-in-out infinite;
+}
+
+@keyframes green-float-decor {
+  0%, 100% {
+    transform: translateX(-50%) translateY(0px) scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: translateX(-50%) translateY(-15px) scale(1.03);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 900px) {
+  .bg-decor {
+    display: none;
+  }
+}
 
 /* Animations */
-.fade-in{animation:fadeIn .6s ease both}
-@keyframes fadeIn{from{opacity:0; transform:translateY(8px)} to{opacity:1; transform:none}}
-@keyframes slideInLeft{from{opacity:0; transform:translateX(-8px)} to{opacity:1; transform:none}}
-.toc-item{animation:slideInLeft .36s ease both}
+.fade-in {
+  animation: fadeIn 0.8s ease both;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideInLeft {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.toc-item {
+  animation: slideInLeft 0.4s ease both;
+}
+
+/* Pulse animation for loading states */
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Shimmer effect for loading */
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* Bounce animation for interactive elements */
+@keyframes bounce {
+  0%, 20%, 53%, 80%, 100% {
+    transform: translateY(0);
+  }
+  40%, 43% {
+    transform: translateY(-10px);
+  }
+  70% {
+    transform: translateY(-5px);
+  }
+  90% {
+    transform: translateY(-2px);
+  }
+}
 
 /* Article styles */
-#article h1{font-size:28px; margin-top:0}
-#article h2{margin-top:28px}
-#article p{color:var(--muted); line-height:1.7}
-#article table{width:100%; border-collapse:collapse}
-#article table th, #article table td{border:1px solid rgba(255,255,255,0.04); padding:8px; color:var(--muted)}
-#article a{color:var(--accent); text-decoration:none}
+#article {
+  position: relative;
+  z-index: 2;
+  color: var(--text-primary);
+  opacity: 1;
+  visibility: visible;
+}
 
-/* Code blocks */
-pre{border-radius:12px; overflow:auto; padding:16px; background:#010617; box-shadow:inset 0 1px 0 rgba(255,255,255,0.02)}
-code{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, 'Roboto Mono', 'Courier New', monospace; font-size:0.95em}
+#article h1 {
+  font-size: var(--font-size-4xl);
+  font-weight: 800;
+  margin-top: 0;
+  margin-bottom: var(--spacing-lg);
+  background: var(--hf-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  line-height: 1.2;
+  position: relative;
+  color: var(--text-primary);
+}
+
+#article h1::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 0;
+  width: 60px;
+  height: 3px;
+  background: var(--accent-gradient);
+  border-radius: 2px;
+}
+
+/* Remove emoji and special characters from TOC links */
+.toc-item a {
+  font-family: var(--font-family);
+}
+
+.toc-item a::after {
+  display: none;
+}
+
+/* Ensure content is visible */
+#article * {
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+#article h2 {
+  font-size: var(--font-size-3xl);
+  font-weight: 700;
+  margin-top: var(--spacing-2xl);
+  margin-bottom: var(--spacing-lg);
+  color: var(--text-primary);
+  position: relative;
+}
+
+#article h2::before {
+  content: '';
+  position: absolute;
+  left: -var(--spacing-lg);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 24px;
+  background: var(--accent-gradient);
+  border-radius: 2px;
+}
+
+#article h3 {
+  font-size: var(--font-size-2xl);
+  font-weight: 600;
+  margin-top: var(--spacing-xl);
+  margin-bottom: var(--spacing-md);
+  color: var(--accent-primary);
+}
+
+#article h4 {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  margin-top: var(--spacing-lg);
+  margin-bottom: var(--spacing-sm);
+  color: var(--text-primary);
+}
+
+#article p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: var(--spacing-lg);
+  font-size: var(--font-size-base);
+}
+
+#article a {
+  color: var(--accent-primary);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: all var(--transition-base);
+  position: relative;
+}
+
+#article a:hover {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent-primary);
+  transform: translateY(-1px);
+}
+
+#article ul, #article ol {
+  margin-bottom: var(--spacing-lg);
+  padding-left: var(--spacing-xl);
+}
+
+#article li {
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-sm);
+  line-height: 1.7;
+}
+
+#article li::marker {
+  color: var(--accent-primary);
+}
+
+#article blockquote {
+  border-left: 4px solid var(--accent-primary);
+  background: var(--surface);
+  padding: var(--spacing-lg);
+  margin: var(--spacing-xl) 0;
+  border-radius: var(--radius-md);
+  font-style: italic;
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-sm);
+}
+
+#article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--spacing-xl) 0;
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+#article table th, #article table td {
+  border: 1px solid var(--border);
+  padding: var(--spacing-md);
+  text-align: left;
+}
+
+#article table th {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+#article table td {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+#article table tr:hover {
+  background: var(--surface-hover);
+}
+
+#article code {
+  background: var(--surface);
+  color: var(--accent-primary);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  border: 1px solid var(--border);
+}
+
+#article pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  margin: var(--spacing-xl) 0;
+  overflow-x: auto;
+  box-shadow: var(--shadow-md);
+}
+
+#article pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+#article img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  margin: var(--spacing-lg) 0;
+}
+
+.loading-title {
+  color: var(--text-primary);
+  animation: pulse 2s ease-in-out infinite;
+  text-align: center;
+  padding: var(--spacing-xl);
+  font-size: var(--font-size-xl);
+}
+
+/* Enhanced code blocks */
+pre {
+  border-radius: var(--radius-md);
+  overflow: auto;
+  padding: var(--spacing-lg);
+  background: #0f1419;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border);
+  position: relative;
+}
+
+pre::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--accent-gradient);
+  opacity: 0.3;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+/* Syntax highlighting improvements */
+.hljs {
+  background: transparent !important;
+  color: var(--text-secondary) !important;
+}
+
+.hljs-keyword {
+  color: #c678dd !important;
+}
+
+.hljs-string {
+  color: #98c379 !important;
+}
+
+.hljs-comment {
+  color: var(--text-muted) !important;
+  font-style: italic;
+}
+
+.hljs-number {
+  color: #d19a66 !important;
+}
+
+.hljs-function {
+  color: #61dafb !important;
+}
 
 /* Heading anchors */
-.heading-anchor{margin-left:8px; opacity:0; transform:translateY(-2px); transition:opacity .12s ease, transform .12s ease; color:var(--muted); text-decoration:none}
-#article h1:hover .heading-anchor, #article h2:hover .heading-anchor, #article h3:hover .heading-anchor{opacity:1; transform:none}
+.heading-anchor {
+  margin-left: var(--spacing-sm);
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: all var(--transition-fast);
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.8em;
+  font-weight: normal;
+}
+
+#article h1:hover .heading-anchor, 
+#article h2:hover .heading-anchor, 
+#article h3:hover .heading-anchor {
+  opacity: 1;
+  transform: translateY(0);
+  color: var(--accent-primary);
+}
+
+.heading-anchor:hover {
+  color: var(--text-primary);
+  transform: scale(1.1);
+}
 
 /* Mark highlight for search */
-mark{background:linear-gradient(90deg, rgba(125,211,252,0.16), rgba(96,165,250,0.12)); padding:2px 4px; border-radius:4px}
+mark {
+  background: var(--accent-gradient);
+  color: white;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+  box-shadow: var(--shadow-sm);
+  animation: green-pulse 1s ease-in-out;
+}
 
-/* Responsive */
-@media (max-width:900px){
-  .sidebar{position:fixed; z-index:30; left:0; top:0; height:100vh; transform:translateX(0); background:linear-gradient(180deg, rgba(11,18,32,0.95), rgba(11,18,32,0.98));}
-  .sidebar.collapsed{transform:translateX(-100%)}
-  .content{padding:20px}
-  .sidebar.collapsed + .content{padding-left:20px}
-  .sidebar{transform:translateX(-8px); transition:transform .28s cubic-bezier(.2,.9,.2,1)}
-  .sidebar:not(.collapsed){transform:translateX(0)}
-  .topnav-inner{padding:0 8px}
-  .nav-links{display:none}
+/* Search results highlight */
+.search-highlight {
+  background: rgba(var(--accent-rgb), 0.15);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  animation: fadeIn 0.3s ease;
+}
+
+/* Responsive design */
+@media (max-width: 1024px) {
+  .content {
+    padding: var(--spacing-xl);
+  }
+  
+  .content-inner {
+    padding: var(--spacing-xl);
+  }
+  
+  #article h1 {
+    font-size: var(--font-size-3xl);
+  }
+  
+  #article h2 {
+    font-size: var(--font-size-2xl);
+  }
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    position: fixed;
+    z-index: 100;
+    left: 0;
+    top: 0;
+    height: 100vh;
+    transform: translateX(-100%);
+    background: rgba(15, 20, 25, 0.98);
+    backdrop-filter: blur(20px);
+    transition: transform var(--transition-slow);
+  }
+  
+  .sidebar:not(.collapsed) {
+    transform: translateX(0);
+  }
+  
+  .content {
+    padding: var(--spacing-lg);
+    margin-left: 0;
+  }
+  
+  .content-inner {
+    padding: var(--spacing-lg);
+  }
+  
+  .topnav-inner {
+    padding: 0 var(--spacing-md);
+  }
+  
+  .nav-links {
+    display: none;
+  }
+  
+  #article h1 {
+    font-size: var(--font-size-2xl);
+  }
+  
+  #article h2 {
+    font-size: var(--font-size-xl);
+  }
+  
+  #article h2::before {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .content {
+    padding: var(--spacing-md);
+  }
+  
+  .content-inner {
+    padding: var(--spacing-md);
+    border-radius: var(--radius-md);
+  }
+  
+  #article h1 {
+    font-size: var(--font-size-xl);
+    margin-bottom: var(--spacing-md);
+  }
+  
+  #article h2 {
+    font-size: var(--font-size-lg);
+    margin-top: var(--spacing-lg);
+    margin-bottom: var(--spacing-md);
+  }
+  
+  #article h3 {
+    font-size: var(--font-size-base);
+  }
+  
+  #article p {
+    font-size: var(--font-size-sm);
+    line-height: 1.7;
+  }
+  
+  #article table {
+    font-size: var(--font-size-xs);
+  }
+  
+  #article table th, #article table td {
+    padding: var(--spacing-sm);
+  }
+  
+  .topnav {
+    padding: var(--spacing-sm) var(--spacing-md);
+  }
+  
+  .topnav .brand {
+    font-size: var(--font-size-base);
+  }
+}
+
+@media (max-width: 480px) {
+  .content {
+    padding: var(--spacing-sm);
+  }
+  
+  .content-inner {
+    padding: var(--spacing-md);
+    border-radius: var(--radius-md);
+  }
+  
+  .topnav {
+    padding: var(--spacing-sm);
+  }
+  
+  .topnav-inner {
+    gap: var(--spacing-sm);
+  }
+  
+  #article h1 {
+    font-size: var(--font-size-lg);
+  }
+  
+  #article h2 {
+    font-size: var(--font-size-base);
+  }
+  
+  #article p {
+    font-size: var(--font-size-xs);
+  }
 }
 
 /* Logo blob animation */
-.logo-blob{display:inline-block; vertical-align:middle; width:12px; height:12px; margin-right:8px; border-radius:50%; background:radial-gradient(circle at 30% 30%, #7dd3fc, #60a5fa); box-shadow:0 6px 18px rgba(96,165,250,0.12); animation:blob 3.6s infinite ease-in-out}
-@keyframes blob{0%{transform:translateY(0) scale(1)}50%{transform:translateY(-3px) scale(1.06)}100%{transform:translateY(0) scale(1)}}
+.logo-blob {
+  display: inline-block;
+  vertical-align: middle;
+  width: 16px;
+  height: 16px;
+  margin-right: var(--spacing-sm);
+  border-radius: 50%;
+  background: var(--hf-gradient);
+  box-shadow: 
+    0 4px 12px rgba(249, 115, 22, 0.3),
+  0 0 20px rgba(var(--accent-rgb), 0.2);
+  animation: green-blob 5s infinite ease-in-out;
+  position: relative;
+}
 
-/* subtle header shadow */
-.content-inner{transition:box-shadow .36s ease, transform .36s ease}
-.content-inner:hover{box-shadow:0 18px 60px rgba(2,6,23,0.7); transform:translateY(-2px)}
+.logo-blob::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  background: white;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.9;
+  animation: green-pulse 4s infinite;
+}
 
-.error-panel{background:linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0.01)); padding:18px; border-radius:12px; color:var(--muted)}
+.logo-blob::after {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 1px solid rgba(var(--accent-rgb), 0.4);
+  border-radius: 50%;
+  animation: green-rotate 8s linear infinite;
+}
+
+@keyframes green-blob {
+  0%, 100% {
+    transform: translateY(0) scale(1);
+    box-shadow: 
+      0 4px 12px rgba(249, 115, 22, 0.3),
+  0 0 20px rgba(var(--accent-rgb), 0.2);
+  }
+  50% {
+    transform: translateY(-3px) scale(1.05);
+    box-shadow: 
+      0 5px 14px rgba(249, 115, 22, 0.4),
+  0 0 22px rgba(var(--accent-rgb), 0.3);
+  }
+}
+
+@keyframes green-rotate {
+  0% { transform: rotate(0deg); opacity: 0.3; }
+  50% { opacity: 0.6; }
+  100% { transform: rotate(360deg); opacity: 0.3; }
+}
+
+@keyframes green-pulse {
+  0%, 100% { opacity: 0.9; transform: translate(-50%, -50%) scale(1); }
+  50% { opacity: 0.8; transform: translate(-50%, -50%) scale(1.05); }
+}
+
+/* Error panel */
+.error-panel {
+  background: var(--surface);
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  text-align: center;
+}
+
+.error-panel h2 {
+  color: var(--error);
+  margin-bottom: var(--spacing-md);
+}
+
+.error-panel a {
+  color: var(--accent-primary);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color var(--transition-base);
+}
+
+.error-panel a:hover {
+  color: var(--text-primary);
+}
+
+/* Loading states */
+.loading {
+  opacity: 0.6;
+  pointer-events: none;
+  position: relative;
+}
+
+.loading::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin: -10px 0 0 -10px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Focus states for accessibility */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  
+  .logo-blob {
+    animation: none;
+  }
+  
+  .bg-decor {
+    animation: none;
+  }
+}
+
+/* Footer styles (appended) */
+.site-footer {
+  background: linear-gradient(135deg, rgba(0,0,0,0.9), rgba(16,16,24,0.9));
+  color: var(--text-primary);
+  padding: var(--spacing-2xl) 0 var(--spacing-lg);
+  border-top: 1px solid rgba(255,255,255,0.03);
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--spacing-lg);
+  display: grid;
+  grid-template-columns: 260px 1fr 220px;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+
+
+.footer-brand { display:flex; flex-direction:column; gap:0.6rem; }
+.footer-brand-link { display:flex; align-items:center; gap:0.8rem; color:var(--text-primary); text-decoration:none }
+.footer-title { font-size:1.25rem; font-weight:700 }
+.footer-desc { color: rgba(255,255,255,0.85); font-size:0.95rem; line-height:1.6 }
+
+.footer-links { display:flex; flex-direction:column; gap:0.55rem; align-items: center; }
+.footer-links a { color:var(--text-secondary); text-decoration:none; transition: color .18s ease; }
+.footer-links a:hover { color:var(--accent-primary); transform:translateX(4px) }
+
+.footer-socials { display:flex; gap:0.6rem; list-style:none; padding:0; margin:0 }
+.footer-socials a { display:inline-flex; align-items:center; gap:0.6rem; color:var(--text-secondary); text-decoration:none; padding:0.35rem 0.6rem; border-radius:8px }
+.footer-socials a:hover { background: rgba(var(--accent-rgb),0.06); color:var(--accent-primary); transform:translateY(-2px) }
+
+.footer-bottom { max-width: var(--max-width); margin: 1.25rem auto 0; padding: var(--spacing-sm) var(--spacing-lg) 0; border-top:1px solid rgba(255,255,255,0.03); text-align:center; color: rgba(255,255,255,0.68); font-size:0.95rem }
+
+@media (max-width: 900px) {
+  .footer-inner { grid-template-columns: 1fr; gap:var(--spacing-md); }
+  .footer-desc { display:none }
+  .footer-brand { align-items:center }
+}
+
+/* Center the Quick Links heading in the middle footer column */
+.footer-inner .footer-col:nth-child(2) h4 {
+  text-align: center;
+  margin-bottom: 0.6rem;
+  color: var(--text-primary);
+}
+

--- a/index.html
+++ b/index.html
@@ -19,507 +19,28 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/5.1.1/marked.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.8.0/highlight.min.js"></script>
 
-  <style>
-    :root {
-      --hf-orange: #ff8a65;
-      --hf-purple: #9b59b6;
-      --hf-dark: #183153;
-      --hf-light: #ffffff;
-      --spacing-sm: 0.5rem;
-      --spacing-md: 1rem;
-      --spacing-lg: 2rem;
-    }
-    
-    .logo-blob {
-      display: inline-block;
-      width: 2em;
-      height: 2em;
-      margin-right: 0.5em;
-      background: linear-gradient(135deg, var(--hf-orange), var(--hf-purple));
-      border-radius: 50%;
-      animation: blob 2.5s infinite ease-in-out;
-      box-shadow: 0 0 15px rgba(255, 138, 101, 0.3);
-    }
-
-    @keyframes blob {
-      0%, 100% {
-        transform: scale(1);
-      }
-      50% {
-        transform: scale(1.1);
-      }
-    }
-
-    .brand {
-      display: flex;
-      align-items: center;
-    }
-
-    /* Subtle shadow animation for header */
-    .site {
-      position: relative;
-    }
-
-    .site::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 4px;
-      background: linear-gradient(to right, transparent, rgba(255,255,255,0.3), transparent);
-      z-index: 1;
-      animation: shine 1.5s infinite;
-    }
-
-    @keyframes shine {
-      0% { background-position: -200% 0; }
-      100% { background-position: 200% 0; }
-    }
-
-    .bg-decor {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 0;
-      pointer-events: none;
-      overflow: hidden;
-    }
-
-    .bg-decor svg {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      opacity: 0.1;
-      animation: float 6s ease-in-out infinite;
-    }
-
-    @keyframes float {
-      0%, 100% {
-        transform: translate(-50%, -50%) scale(1);
-      }
-      50% {
-        transform: translate(-50%, -50%) scale(1.05);
-      }
-    }
-
-    /* Top navigation bar styles */
-    .topnav {
-      background: linear-gradient(135deg, var(--hf-dark), var(--hf-purple));
-      color: var(--hf-light);
-      padding: var(--spacing-md) var(--spacing-lg);
-      position: sticky;
-      top: 0;
-      z-index: 1000;
-      box-shadow: 0 2px 20px rgba(0,0,0,0.2);
-    }
-
-    .topnav-inner {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
-
-    .nav-links {
-      display: flex;
-      gap: 1.5rem;
-    }
-
-    .nav-links a {
-      position: relative;
-      padding: 0.5rem 1rem;
-      color: var(--hf-light);
-      text-decoration: none;
-      transition: all 0.3s ease;
-    }
-
-    .nav-links a:hover {
-      color: var(--hf-orange);
-    }
-
-    .nav-actions {
-      display: flex;
-      gap: 1rem;
-    }
-
-    .nav-btn {
-      background: none;
-      border: none;
-      color: #9fb1c7;
-      font-size: 1.2rem;
-      cursor: pointer;
-      transition: color 0.3s;
-    }
-
-    .nav-btn:hover {
-      color: #fff;
-    }
-
-    .nav-cta {
-      background: linear-gradient(135deg, var(--hf-orange), var(--hf-purple));
-      padding: 0.8rem 1.5rem;
-      border-radius: 50px;
-      color: var(--hf-light);
-      text-decoration: none;
-      transition: all 0.3s ease;
-      box-shadow: 0 4px 15px rgba(155, 89, 182, 0.3);
-    }
-
-    .nav-cta:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(155, 89, 182, 0.4);
-    }
-
-    /* Content layout and search enhancements */
-    .content {
-      padding: var(--spacing-lg);
-      background: linear-gradient(135deg, rgba(155, 89, 182, 0.1), rgba(255, 138, 101, 0.1));
-      min-height: calc(100vh - 60px);
-    }
-
-    .content-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-      background: rgba(255, 255, 255, 0.02);
-      backdrop-filter: blur(10px);
-      border-radius: 20px;
-      padding: var(--spacing-lg);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    }
-
-    .search-wrapper {
-      position: relative;
-      max-width: 600px;
-      margin: var(--spacing-md) auto;
-    }
-
-    .search-wrapper input {
-      width: 100%;
-      padding: 1rem 3rem 1rem 1.5rem;
-      background: rgba(255, 255, 255, 0.1);
-      border: 2px solid rgba(255, 255, 255, 0.1);
-      border-radius: 50px;
-      color: var(--hf-light);
-      font-size: 1.1rem;
-      transition: all 0.3s ease;
-    }
-
-    .search-wrapper input:focus {
-      background: rgba(255, 255, 255, 0.15);
-      border-color: var(--hf-purple);
-      box-shadow: 0 0 25px rgba(155, 89, 182, 0.2);
-      outline: none;
-    }
-
-    .search-ico {
-      position: absolute;
-      right: 1.2rem;
-      top: 50%;
-      transform: translateY(-50%);
-      color: var(--hf-light);
-      opacity: 0.7;
-      pointer-events: none;
-    }
-
-    /* Improved readability */
-    #article {
-      font-size: 16px;
-      line-height: 1.8;
-      color: var(--hf-light);
-      max-width: 800px;
-      margin: 0 auto;
-    }
-
-    #article h1 {
-      font-size: 2.5rem;
-      margin: 2rem 0 1.5rem;
-      color: var(--hf-orange);
-      background: linear-gradient(90deg, var(--hf-orange), var(--hf-purple));
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-    }
-
-    #article h2 {
-      font-size: 1.8rem;
-      margin: 2rem 0 1rem;
-      color: var(--hf-light);
-    }
-
-    #article h3 {
-      font-size: 1.4rem;
-      margin: 1.5rem 0 1rem;
-      color: var(--hf-orange);
-    }
-
-    #article p {
-      margin-bottom: 1.2rem;
-      font-size: 1.1rem;
-      color: rgba(255, 255, 255, 0.9);
-    }
-
-    #article ul, #article ol {
-      padding-left: 1.5rem;
-      margin-bottom: 1.2rem;
-    }
-
-    #article li {
-      margin-bottom: 0.5rem;
-    }
-
-    #article code {
-      background: rgba(155, 89, 182, 0.1);
-      padding: 0.2em 0.4em;
-      border-radius: 3px;
-      font-size: 0.9em;
-    }
-
-    #article pre {
-      margin: 1.5rem 0;
-      padding: 1rem;
-      border-radius: 8px;
-      background: rgba(0, 0, 0, 0.3);
-    }
-
-    #article table {
-      width: 100%;
-      margin: 1.5rem 0;
-      border-collapse: collapse;
-    }
-
-    #article th, #article td {
-      padding: 0.8rem;
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      background: rgba(255, 255, 255, 0.02);
-    }
-
-    #article th {
-      background: rgba(155, 89, 182, 0.1);
-      color: var(--hf-orange);
-    }
-
-    /* Enhanced search results */
-    .search-highlight {
-      background: linear-gradient(120deg, rgba(255, 138, 101, 0.2), rgba(155, 89, 182, 0.2));
-      border-radius: 3px;
-      padding: 0.2em 0;
-    }
-
-    .search-wrapper input:focus + .search-ico {
-      color: var(--hf-orange);
-      opacity: 1;
-    }
-
-    /* Smooth scroll padding for header */
-    html {
-      scroll-padding-top: 80px;
-    }
-
-    /* Mobile optimizations */
-    @media (max-width: 768px) {
-      #article {
-        font-size: 15px;
-        padding: 0 1rem;
-      }
-
-      #article h1 { font-size: 2rem; }
-      #article h2 { font-size: 1.5rem; }
-      #article h3 { font-size: 1.2rem; }
-    }
-
-    /* Sidebar styles for collapsed state */
-    .sidebar.collapsed {
-      width: 80px;
-    }
-
-    .sidebar.collapsed .brand {
-      justify-content: center;
-    }
-
-    .sidebar.collapsed .brand .logo-blob {
-      margin-right: 0;
-    }
-
-    .sidebar.collapsed #toc {
-      display: none;
-    }
-
-    .sidebar.collapsed .toc-toggle {
-      display: none;
-    }
-
-    .sidebar.collapsed .sidebar-footer {
-      display: none;
-    }
-
-    .sidebar.collapsed .search-wrapper {
-      display: none;
-    }
-
-    .sidebar.collapsed .nav-btn {
-      display: none;
-    }
-
-    .sidebar.collapsed .nav-cta {
-      display: none;
-    }
-
-    @keyframes fadeIn {
-      from { opacity: 0; transform: translateY(20px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-
-    .fade-in {
-      animation: fadeIn 0.8s ease-out forwards;
-    }
-
-    /* Smooth transitions */
-    .toc-item a {
-      transition: all 0.3s ease;
-    }
-
-    .toc-item a:hover {
-      transform: translateX(10px);
-      color: var(--hf-orange);
-    }
-
-    /* Active link indicator */
-    .toc-item a.active {
-      color: var(--hf-orange);
-      font-weight: 600;
-      padding-left: 1rem;
-      border-left: 3px solid var(--hf-orange);
-    }
-
-    /* Search results highlight */
-    mark {
-      background: linear-gradient(120deg, var(--hf-orange), var(--hf-purple));
-      padding: 0.1em 0.3em;
-      border-radius: 3px;
-      color: var(--hf-light);
-    }
-
-    /* Section highlight animation */
-    .highlight-section {
-      animation: highlight-pulse 1s ease-out;
-    }
-
-    @keyframes highlight-pulse {
-      0% { background: rgba(255, 138, 101, 0.2); }
-      100% { background: transparent; }
-    }
-
-    /* Better sidebar positioning */
-    .sidebar {
-      position: sticky;
-      top: 60px;
-      height: calc(100vh - 60px);
-      overflow-y: auto;
-      background: rgba(24, 49, 83, 0.95);
-      backdrop-filter: blur(10px);
-      padding: 1rem;
-    }
-
-    /* Footer Styles */
-    .site-footer {
-      background: linear-gradient(135deg, rgba(24,49,83,0.96), rgba(155,89,182,0.92));
-      backdrop-filter: blur(12px);
-      color: var(--hf-light);
-      margin-top: var(--spacing-lg);
-      box-shadow: 0 -6px 25px rgba(0,0,0,0.22);
-      padding: var(--spacing-lg) 0 var(--spacing-md);
-    }
-
-    .footer-inner {
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 0 var(--spacing-lg);
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: var(--spacing-lg);
-      align-items: start;
-    }
-
-    .footer-brand {
-      display: flex;
-      gap: 0.9rem;
-      align-items: flex-start;
-    }
-
-    .footer-brand .logo-blob {
-      width: 2.4em;
-      height: 2.4em;
-      margin-right: 0;
-      box-shadow: 0 0 24px rgba(255,138,101,0.18);
-    }
-
-    .footer-col h4 {
-      margin: 0 0 var(--spacing-sm);
-      font-size: 1.15rem;
-      color: var(--hf-orange);
-    }
-
-    .footer-title {
-      font-size: 1.25rem;
-      font-weight: 600;
-    }
-
-    .footer-desc {
-      margin: 0.45rem 0 0;
-      color: rgba(255,255,255,0.86);
-      font-size: 0.96rem;
-      line-height: 1.6;
-    }
-
-    .footer-links {
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      margin: 0;
-    }
-
-    .footer-links a {
-      color: rgba(255,255,255,0.85);
-      text-decoration: none;
-      transition: color 0.22s ease, transform 0.22s ease;
-    }
-
-    .footer-links a:hover {
-      color: var(--hf-orange);
-      transform: translateX(4px);
-    }
-
-    .footer-socials {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
-
-    .footer-socials a {
-      color: rgba(255,255,255,0.88);
-      text-decoration: none;
-      transition: transform 0.18s ease, color 0.18s ease;
-    }
-
-    .footer-socials a:hover {
-      color: var(--hf-orange);
-      transform: translateX(6px);
-    }
-
-    .footer-bottom {
-      max-width: 1200px;
-      margin: 1.25rem auto 0;
-      padding: var(--spacing-sm) var(--spacing-lg) 0;
-      border-top: 1px solid rgba(255,255,255,0.04);
-      text-align: center;
-      color: rgba(255,255,255,0.72);
-      font-size: 0.95rem;
-    }
-  </style>
+  <!-- Theme variables and styles live in assets/style.css. The inline block was removed to avoid duplication.
+       Below we pick a random accent palette at runtime and set CSS variables so the black theme gets a fresh accent. -->
+  <script>
+    (function(){
+      const palettes = [
+        {name:'violet-orange', a:'#9b59b6', b:'#f97316', rgb:'155,89,182'},
+        {name:'teal-cyan', a:'#06b6d4', b:'#06b6d4', rgb:'6,182,212'},
+        {name:'indigo-pink', a:'#6366f1', b:'#ec4899', rgb:'99,102,241'},
+        {name:'sunset', a:'#ff8a65', b:'#f97316', rgb:'255,138,101'},
+        {name:'mint', a:'#22c55e', b:'#16a34a', rgb:'34,197,94'}
+      ];
+      const p = palettes[Math.floor(Math.random()*palettes.length)];
+      const r = document.documentElement;
+      r.style.setProperty('--accent-1', p.a);
+      r.style.setProperty('--accent-2', p.b);
+      r.style.setProperty('--accent-rgb', p.rgb);
+      r.style.setProperty('--accent-gradient', `linear-gradient(135deg, ${p.a}, ${p.b})`);
+      r.style.setProperty('--accent-primary', p.a);
+      r.style.setProperty('--accent-secondary', p.b);
+      r.style.setProperty('--hf-gradient', `linear-gradient(135deg, ${p.a}, ${p.b})`);
+    })();
+  </script>
 </head>
 <body>
   <header class="topnav" role="banner">
@@ -621,7 +142,7 @@
             a.className = 'heading-anchor';
             a.href = '#' + id;
             a.title = 'Link to ' + h.textContent.trim();
-            a.innerHTML = '¶';
+            a.innerHTML = '';
             h.appendChild(a);
           });
 
@@ -753,10 +274,19 @@
 
     // TOC toggle for small screens
     document.getElementById('toc-toggle').addEventListener('click', (e) => {
+      e.preventDefault();
       const sidebar = document.getElementById('sidebar');
-      const expanded = sidebar.classList.toggle('collapsed');
-      e.target.textContent = expanded ? 'Show' : 'Hide';
-      e.target.setAttribute('aria-expanded', String(!expanded));
+      const isCollapsed = sidebar.classList.contains('collapsed');
+      
+      if (isCollapsed) {
+        sidebar.classList.remove('collapsed');
+        e.target.textContent = 'Hide';
+        e.target.setAttribute('aria-expanded', 'true');
+      } else {
+        sidebar.classList.add('collapsed');
+        e.target.textContent = 'Show';
+        e.target.setAttribute('aria-expanded', 'false');
+      }
     });
 
     // Navbar interactions: focus search and toggle sidebar
@@ -764,7 +294,14 @@
       const s = document.getElementById('search'); if (s) { s.focus(); s.scrollIntoView({behavior:'smooth', block:'center'}); }
     });
     document.getElementById('hamburger').addEventListener('click', () => {
-      const sidebar = document.getElementById('sidebar'); sidebar.classList.toggle('collapsed');
+      const sidebar = document.getElementById('sidebar');
+      const isCollapsed = sidebar.classList.contains('collapsed');
+      
+      if (isCollapsed) {
+        sidebar.classList.remove('collapsed');
+      } else {
+        sidebar.classList.add('collapsed');
+      }
     });
 
     // keyboard shortcut: press '/' to focus search
@@ -795,52 +332,35 @@
   </script>
 
   <!-- Footer Section  -->
-  <footer class="site-footer">
+  <footer class="site-footer" role="contentinfo">
     <div class="footer-inner">
       <div class="footer-col footer-brand">
-        <span class="logo-blob" aria-hidden="true"></span>
-        <span class="footer-title">Hacktoberfest 2025</span>
+        <a href="./" class="footer-brand-link"><span class="logo-blob" aria-hidden="true"></span><span class="footer-title">Hacktoberfest 2025</span></a>
+        <p class="footer-desc">A small guide to help you get started contributing to open source during Hacktoberfest 2025.</p>
       </div>
 
       <div class="footer-col">
         <h4>Quick Links</h4>
         <nav class="footer-links" aria-label="Footer navigation">
           <a href="#what-is-hacktoberfest">Overview</a>
-          <a href="https://github.com/avinash201199/Hacktoberfest2025" target="_blank" rel="noopener">Projects</a>
+          <a href="#my-beginners-friendly-repos-to-contribute">Projects</a>
+          <a href="#how-to-participate-step-by-step">How To</a>
           <a href="#useful-resources--repositories">Resources</a>
         </nav>
       </div>
 
       <div class="footer-col">
         <h4>Stay Connected</h4>
-        <div class="footer-socials">
-          <a href="https://github.com/avinash201199/Hacktoberfest2025" target="_blank" rel="noopener" aria-label="GitHub">
-            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="margin-right:6px;">
-              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 
-              3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 
-              0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61 
-              -.546-1.385-1.333-1.754-1.333-1.754-1.09-.744.084-.729.084-.729 
-              1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.807 
-              1.305 3.492.998.108-.776.418-1.305.76-1.605-2.665-.3-5.466-1.334-5.466-5.93 
-              0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 
-              0 0 1.005-.322 3.3 1.23a11.5 11.5 0 0 1 3-.405c1.02.005 
-              2.045.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23 
-              .645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 
-              1.23 3.22 0 4.61-2.805 5.625-5.475 
-              5.92.435.375.81 1.096.81 2.22 
-              0 1.606-.015 2.896-.015 3.286 
-              0 .315.21.69.825.57C20.565 22.092 
-              24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-            </svg>
-            GitHub
-          </a>
-        </div>
+        <ul class="footer-socials" aria-label="Social links">
+          <li><a href="https://github.com/avinash201199/Hacktoberfest2025" target="_blank" rel="noopener" aria-label="GitHub"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.333-1.754-1.333-1.754-1.09-.744.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.807 1.305 3.492.998.108-.776.418-1.305.76-1.605-2.665-.3-5.466-1.334-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23a11.5 11.5 0 0 1 3-.405c1.02.005 2.045.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.435.375.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg> GitHub</a></li>
+        </ul>
       </div>
     </div>
 
     <div class="footer-bottom">
-      <p><strong>Hacktoberfest 2025</strong>. Open-source & community-driven.</p>
+      <p><small>&copy; <span id="year">2025</span> <strong>Hacktoberfest 2025</strong> — Open-source & community-driven.</small></p>
     </div>
   </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
This PR removes the pilcrow (¶) character from the heading anchors in index.html for a cleaner UI.